### PR TITLE
Update gitignore to exclude virtual environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 ProgramDocs/
 SLiCAP_python.egg-info/
 SLiCAP/SLiCAPsetting/SLiCAPsetting.py
+.venv/


### PR DESCRIPTION
Very simple change to ignore virtual environment files for those who install SLiCAP in a virtual environment.