### PR TITLE
Fixed circuit.params inconsistency in circuit.updateParams()

### DIFF
--- a/SLiCAP/SLiCAPprotos/SLiCAPprotos.py
+++ b/SLiCAP/SLiCAPprotos/SLiCAPprotos.py
@@ -334,8 +334,6 @@ class circuit(object):
         for par in self.params:
             if par != ini.Laplace and par != ini.frequency and par not in list(self.parDefs.keys()):
                 undefined.append(par)
-            else:
-                self.params.remove(par)
         self.params = undefined
         return
         


### PR DESCRIPTION
Undefined parameters could be erroneously removed from the circuit.params list in circuit.updateParams().

This happened when entries were removed from circuit.params inside the loop over circuit.params. This resulted in not all parameters being processed. Consequently, they are lost when circuit.params is reassigned to the array of undefined parameters.