### PR TITLE
Unit test for SLiCAPmath.det()

### DIFF
--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,0 +1,46 @@
+import pytest
+import sympy as sp
+
+from SLiCAP import *  # TODO: change imports when import chain is reworked
+import SLiCAP.SLiCAPmath as sm
+
+SYMBOLIC_MATRIX = sp.sympify(
+    "Matrix([[0, 0, 0, 0, 0, 1.0, 0],\
+             [0, -2.0, 0, 0, 1.0*g_m1, 1.0*g_m1, 0],\
+             [0, 0, -2.0, 1.0*g_m2, -1.0*g_m2, 0, 0],\
+             [0, 1.0, 0, 0.5*c_i2*s + 0.5/r_o1, -0.5*c_i2*s + 0.5/r_o1, 0, 0],\
+             [0, 1.0, -1.0, -0.5*c_i2*s + 0.5/r_o1, 0.5*c_i1*s + 0.5*c_i2*s + 0.5/r_o2 + 0.5/r_o1 + 1.0/R, 0.5*c_i1*s, -0.5/r_o2],\
+             [1.0, 0, 0, 0, 0.5*c_i1*s, 0.5*c_i1*s, 0],\
+             [0, 0, 1.0, 0, -0.5/r_o2, 0, 0.5/r_o2 + 1.0/R_L]])"
+    )
+
+# Calculated offline with SymPy's det()
+DETERMINANT = sp.sympify(
+    "-1.0*(0.5*R*R_L*c_i1*c_i2*r_o1*s**2 + 0.5*R*R_L*c_i1*s\
+    + 1.0*R*R_L*c_i2*g_m1*r_o1*s + 2.0*R*R_L*c_i2*s + 1.0*R*c_i1*c_i2*r_o1*r_o2*s**2\
+    + 1.0*R*c_i1*r_o2*s + 2.0*R*c_i2*g_m1*r_o1*r_o2*s + 1.0*R*c_i2*r_o1*s\
+    + 4.0*R*c_i2*r_o2*s + 1.0*R*g_m1*g_m2*r_o1*r_o2 + 2.0*R*g_m2*r_o2 + 1.0*R\
+    + 1.0*R_L*c_i2*r_o1*s + 1.0*R_L + 2.0*c_i2*r_o1*r_o2*s + 2.0*r_o2)/(R*R_L*r_o1*r_o2)"
+    )
+
+
+def test_det_empty():
+    # Determinant of empty matrix should throw an exception
+    with pytest.raises(ValueError):
+        sm.det(sp.Matrix([]))
+
+
+def test_det_nonsq():
+    # Determinant of non-square matrix should throw an exception
+    with pytest.raises(TypeError):
+        sm.det(sp.Matrix([1, 2, 3]))
+
+
+@pytest.mark.parametrize("matrix, determinant", [
+        (sp.Matrix([[0, 0], [0, 0]]), sp.N(0)),
+        (sp.Matrix([[1, 2], [-1, -2]]), sp.N(0)),
+        (sp.Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), sp.N(1)),
+        (SYMBOLIC_MATRIX, DETERMINANT),
+    ])
+def test_det(matrix, determinant):
+    assert sp.simplify(sm.det(matrix) - determinant) == 0

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -4,23 +4,25 @@ import sympy as sp
 from SLiCAP import *  # TODO: change imports when import chain is reworked
 import SLiCAP.SLiCAPmath as sm
 
-SYMBOLIC_MATRIX = sp.sympify(
-    "Matrix([[0, 0, 0, 0, 0, 1.0, 0],\
-             [0, -2.0, 0, 0, 1.0*g_m1, 1.0*g_m1, 0],\
-             [0, 0, -2.0, 1.0*g_m2, -1.0*g_m2, 0, 0],\
-             [0, 1.0, 0, 0.5*c_i2*s + 0.5/r_o1, -0.5*c_i2*s + 0.5/r_o1, 0, 0],\
-             [0, 1.0, -1.0, -0.5*c_i2*s + 0.5/r_o1, 0.5*c_i1*s + 0.5*c_i2*s + 0.5/r_o2 + 0.5/r_o1 + 1.0/R, 0.5*c_i1*s, -0.5/r_o2],\
-             [1.0, 0, 0, 0, 0.5*c_i1*s, 0.5*c_i1*s, 0],\
-             [0, 0, 1.0, 0, -0.5/r_o2, 0, 0.5/r_o2 + 1.0/R_L]])"
+SYMBOLIC_MATRIX = sp.sympify("""Matrix([
+        [0, 0, 0, 0, 0, 1.0, 0],
+        [0, -2.0, 0, 0, 1.0*g_m1, 1.0*g_m1, 0],
+        [0, 0, -2.0, 1.0*g_m2, -1.0*g_m2, 0, 0],
+        [0, 1.0, 0, 0.5*c_i2*s + 0.5/r_o1, -0.5*c_i2*s+ 0.5/r_o1, 0, 0],
+        [0, 1.0, -1.0, -0.5*c_i2*s + 0.5/r_o1,
+         0.5*c_i1*s+ 0.5*c_i2*s + 0.5/r_o2 + 0.5/r_o1 + 1.0/R, 0.5*c_i1*s, -0.5/r_o2],
+        [1.0, 0, 0, 0, 0.5*c_i1*s, 0.5*c_i1*s, 0],
+        [0, 0, 1.0, 0, -0.5/r_o2, 0, 0.5/r_o2 + 1.0/R_L]])"""
     )
 
 # Calculated offline with SymPy's det()
-DETERMINANT = sp.sympify(
-    "-1.0*(0.5*R*R_L*c_i1*c_i2*r_o1*s**2 + 0.5*R*R_L*c_i1*s\
-    + 1.0*R*R_L*c_i2*g_m1*r_o1*s + 2.0*R*R_L*c_i2*s + 1.0*R*c_i1*c_i2*r_o1*r_o2*s**2\
-    + 1.0*R*c_i1*r_o2*s + 2.0*R*c_i2*g_m1*r_o1*r_o2*s + 1.0*R*c_i2*r_o1*s\
-    + 4.0*R*c_i2*r_o2*s + 1.0*R*g_m1*g_m2*r_o1*r_o2 + 2.0*R*g_m2*r_o2 + 1.0*R\
-    + 1.0*R_L*c_i2*r_o1*s + 1.0*R_L + 2.0*c_i2*r_o1*r_o2*s + 2.0*r_o2)/(R*R_L*r_o1*r_o2)"
+DETERMINANT = sp.sympify("""
+    -1.0*(0.5*R*R_L*c_i1*c_i2*r_o1*s**2 + 0.5*R*R_L*c_i1*s + 1.0*R*R_L*c_i2*g_m1*r_o1*s
+    + 2.0*R*R_L*c_i2*s + 1.0*R*c_i1*c_i2*r_o1*r_o2*s**2
+    + 1.0*R*c_i1*r_o2*s + 2.0*R*c_i2*g_m1*r_o1*r_o2*s + 1.0*R*c_i2*r_o1*s
+    + 4.0*R*c_i2*r_o2*s + 1.0*R*g_m1*g_m2*r_o1*r_o2 + 2.0*R*g_m2*r_o2 + 1.0*R
+    + 1.0*R_L*c_i2*r_o1*s + 1.0*R_L + 2.0*c_i2*r_o1*r_o2*s + 2.0*r_o2)/(R*R_L*r_o1*r_o2)
+    """
     )
 
 
@@ -37,6 +39,7 @@ def test_det_nonsq():
 
 
 @pytest.mark.parametrize("matrix, determinant", [
+        (sp.Matrix([-1.5e-5]), sp.N(-1.5e-5)),
         (sp.Matrix([[0, 0], [0, 0]]), sp.N(0)),
         (sp.Matrix([[1, 2], [-1, -2]]), sp.N(0)),
         (sp.Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), sp.N(1)),

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -9,7 +9,7 @@ import os
 
 def test_pytest():
     assert 4==4
-    
+
 def test_CSresnoise():
     ini.installPath = os.getcwd() + '/'
     ini.projectPath = ini.installPath + 'files/examples/CSstage/'
@@ -31,14 +31,14 @@ def test_CSresnoise():
     IC      = i1.getParValue('IC_X1')
     IC_CRIT = i1.getParValue('IC_CRIT_X1')
     I_D     = I_D*IC_CRIT/IC
-    
+
     i1.circuit.defPar('ID', I_D)
     R_N   = i1.getParValue('R_N_X1')
     R_s   = i1.getParValue('R_s')
     f_T   = i1.getParValue('f_T_X1')
     g_m   = i1.getParValue('g_m_X1')
     Width = i1.getParValue('W')
-    
+
     i1.setSource('V1')
     i1.setDetector('V_out')
     i1.setGainType('vi')
@@ -46,11 +46,11 @@ def test_CSresnoise():
     i1.setSimType('numeric')
     noise_result = i1.execute()
     # plotSweep('Inoise', 'Source-referred noise spectrum', noise_result, 1e8, 1e11, 100, funcType = 'inoise', show=False)
-    
+
     # Calculate the noise figure at critical inversion and the given width
     tot_inoise      = rmsNoise(noise_result, 'inoise', 1e9, 5e9)
     tot_inoise_src  = rmsNoise(noise_result, 'inoise', 1e9, 5e9, source = noise_result.source)
-    
+
     NF              = 20*sp.log(tot_inoise/tot_inoise_src)/sp.log(10)
     print(NF)
     shifted = int(NF*1000)
@@ -79,18 +79,6 @@ def test_lex2():
     print('\nnumber of errors =', lexer.errCount, '\n')
     #Add assert statement
 
-def test_matrix():
-        s = ini.Laplace
-        MNA = matrix([[5.0e-12*s + 0.01, 0, 0, -5.0e-12*s - 0.01, 0, 0, 0, 0, 1],
-                      [0, 1.98e-11*s + 0.0001, -1.2e-11*s, -1.8e-12*s - 1.0e-5, 0, 0, 0, 0, 0],
-                      [0, -1.2e-11*s, 2.8e-11*s + 0.001, 0, -1.0e-11*s - 0.001, 0, 0, -1, 0],
-                      [-5.0e-12*s - 0.01, -1.8e-12*s - 1.0e-5, 0, 1.0068e-9*s + 0.01101, 0, 0, 1, 0, 0],
-                      [0, 0, -1.0e-11*s - 0.001, 0, 1.0e-11*s + 0.001, 1, 0, 1, 0],
-                      [0, 0, 0, 0, 1, 0, 0, 0, 0],
-                      [0, 0, 0, 1, 0, 0, -1.0e-6*s, -3.1623e-11*s, 0],
-                      [0, 0, -1, 0, 1, 0, -3.1623e-11*s, -1.0e-9*s, 0],
-                      [2.048e-20*s**3 + 2.688e-11*s**2 + 0.0016*s + 1, 0, 0, 0, 0, 0, 0, 0, 0]])
-        print(MNA.determinant())
 
 def test_yacc():
     ini.installPath = os.getcwd() + '/'
@@ -186,4 +174,3 @@ def test_python_maxima():
     proto_transfer = sp.sympify('A/(1+s*tau)')
     circuit_component_values = equateCoeffs(proto_transfer, circuit_transfer, noSolve=['A','tau'], numeric=False)
     print(circuit_component_values)
-


### PR DESCRIPTION
Added unit tests for the determinant solver:
- Wrong input (empty matrix, non-square matrix): they FAIL but could be handled in a wrapper with no loss of efficiency. Discussion for implementation?
- One-element matrix: FAILs because base case of recursion is size 2x2. Could also be handled in wrapper as corner case.
- Simple numerical matrices: 2x2 zeros, 2x2 linear combination, 3x3 identity. 3x PASS.
- 7x7 symbolic matrix: Determinant calculated with SymPy and included in test file. PASS.