### PR TITLE
Moved auxiliary functions to SLiCAP.py

### DIFF
--- a/SLiCAP/SLiCAP.py
+++ b/SLiCAP/SLiCAP.py
@@ -7,7 +7,39 @@ When working with Jupyter notebooks the main imort module is SLiCAPnotebook.py.
 It will import SLiCAP.py and some extra modules for displaying LaTeX, SVG and
 RST in the Jupyter notebooks.
 """
+
+import os
+import shutil
+
 from SLiCAP.SLiCAPdesignData import *
+
+
+def makeDir(dirName):
+    """
+    Create the directory 'dirName' if it does not yet exist.
+
+    :param dirName: Name of the ditectory.
+    :type dirName: str
+    """
+    # FIXME: existence check might be redundant.
+    # Check https://docs.python.org/3/library/os.html#os.makedirs
+    if not os.path.exists(dirName):
+        os.makedirs(dirName)
+
+
+def copyNotOverwrite(src, dest):
+    """
+    Copies the file 'src' to 'dest' if the latter one does not exist.
+
+    :param src: Name of the source file.
+    :type src: str
+
+    :param dest: Name of the desitination file.
+    :type dest: str
+    """
+    if not os.path.exists(dest):
+        shutil.copy2(src, dest)
+
 
 try:
     __IPYTHON__
@@ -56,10 +88,10 @@ def initProject(name, port=ini.PORT):
     :param name: Name of the project will be passed to an instance of the
                  SLiCAPproject object.
     :type name: str
-    
+
     :param port: Port number for communication with maxima CAS (> 8000).
     :type port: int
-    
+
     :return:     SLiCAPproject
     :rtype:      SLiCAP.SLiCAPproject
 
@@ -143,18 +175,18 @@ def initProject(name, port=ini.PORT):
         # Create the libraries
     if len(SLiCAPCIRCUITS) == 0:
         makeLibraries()
-    return prj    
+    return prj
 
 def makeNetlist(fileName, cirTitle):
     """
     Creates a netlist from a schematic file generated with LTspice or gschem.
-    
+
     - LTspice: '.asc' file
     - gschem: '.sch' file
-    
+
     :param fileName: Name of the file, relative to **ini.circuitPath**
     :type fileName: str
-    
+
     :param cirTitle: Title of the schematic.
     :type cirTitle: str
     """
@@ -168,7 +200,7 @@ def makeNetlist(fileName, cirTitle):
         if fileType == 'asc':
             file = os.path.abspath(baseFileName + '.asc')
             print(file)
-            if platform.system() == 'Windows':    
+            if platform.system() == 'Windows':
                 file = file.replace('\\','\\\\')
                 subprocess.run([ini.ltspice, '-netlist', file])
             else:
@@ -186,13 +218,13 @@ def makeNetlist(fileName, cirTitle):
             outputfile = os.path.abspath(baseFileName + '.net')
             inputfile = os.path.abspath(baseFileName + '.sch')
             print('input: ',inputfile, ' output: ', outputfile)
-            if platform.system() != 'Windows':    
+            if platform.system() != 'Windows':
                 try:
                     subprocess.run(['lepton-netlist', '-g', 'spice-noqsi', '-o', outputfile, inputfile])
                 except:
                     print("Could not generate netlist using Lepton-eda")
             try:
-                if platform.system() == 'Windows':    
+                if platform.system() == 'Windows':
                     outputfile = outputfile.replace('\\','\\\\')
                     inputfile = inputfile.replace('\\','\\\\')
                 subprocess.run(['gnetlist', '-q', '-g', 'spice-noqsi', '-o', outputfile, inputfile])

--- a/SLiCAP/SLiCAPprotos/SLiCAPprotos.py
+++ b/SLiCAP/SLiCAPprotos/SLiCAPprotos.py
@@ -142,12 +142,12 @@ class circuit(object):
             - Gxxx, model = 'G', output port: 'Io_Gxxx'
             - Hxxx, input port: 'Ii_Hxxx', output port: 'Io_xxx'
         """
-        
+
         self.controlled = []
         """
         (*list*) with reference designators (*str*) of controlled sources.
         """
-        
+
         self.varIndex   = {}
         """
         (*dict*) with key-value pairs:
@@ -157,7 +157,7 @@ class circuit(object):
           before elemination of the row anmd column associated with the
           reference node '0'.
         """
-        
+
     def delPar(self, parName):
         """
         Deletes a parameter definition and updates the list
@@ -318,7 +318,7 @@ class circuit(object):
             print("Error: parameter '{0}' has not been defined.".format(str(parNames)))
             parValue = None
         return parValue
-    
+
     def updateParams(self):
         """
         Updates self.params (list with undefined parameters) after modification
@@ -347,44 +347,44 @@ class circuit(object):
                 undefined.append(par)
         self.params = undefined
         return
-        
+
     def getElementValue(self, elementID, param, numeric):
         """
         Returns the value or expression of one or more circuit elements.
-        
-        If instruction.numeric == True it will perform a full recursive 
+
+        If instruction.numeric == True it will perform a full recursive
         substitution of all circuit parameter definitions.
-        
-        This method is called by instruction.circuit.getElementValue() with 
+
+        This method is called by instruction.circuit.getElementValue() with
         keyword arg numeric = True if instruction.simType is set to 'numeric'.
-        
+
         :param elementID: name(s) of the element(s)
-        :type elementID: str, list 
-        
+        :type elementID: str, list
+
         :param param: name of the parameter (equal for all elements):
-            
+
                       - 'value': Laplace value
                       - 'dc': DC value (independent sources only)
                       - 'noise': Noise spectral density (independent sources only)
                       - 'dcvar': DC variance (independent sources only)
-                      
+
         :type param: str
-        
+
         :return: if type(parNames) == list:
-            
-                 return value = dict with key-value pairs: key (*sympy.core.symbol.Symbol*): 
-                 name of the parameter, value (*int, float, sympy expression*): 
+
+                 return value = dict with key-value pairs: key (*sympy.core.symbol.Symbol*):
+                 name of the parameter, value (*int, float, sympy expression*):
                  value of the parameter
-                 
+
                  else:
                  value or expression
-                 
+
         :rtype: dict, float, int, sympy.Expr
-        
+
         :Example:
-         
+
         >>> # Create an instance if a SLiCAP instruction
-        >>> my_instr = instruction()  
+        >>> my_instr = instruction()
         >>> # Create my_instr.circuit from the netlist 'myFirstRCnetwork.cir'
         >>> my_instr.setCircuit('myFirstRCnetwork.cir')
         >>> # Obtain the numeric value of 'R1' and 'C1':
@@ -880,7 +880,7 @@ def initAll():
 
 class allResults(object):
     """
-    Return  structure for results, has attributes with 
+    Return  structure for results, has attributes with
     instruction data and execution results.
     """
     def __init__(self):
@@ -931,7 +931,7 @@ class allResults(object):
         """
         DC solution of the network.
         """
-        
+
         self.timeSolve   = []
         """
         Time-domain solution of the network.
@@ -975,7 +975,7 @@ class allResults(object):
         """
         MNA matrix.
         """
-        
+
         self.A           = None
         """
         Base conversion matrix.
@@ -1113,17 +1113,17 @@ class allResults(object):
 
         self.stepList = []
         """
-        List with values for step method 'list'.  
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+        List with values for step method 'list'.
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be a deep copy.
         """
 
         self.stepArray = []
         """
-        Array (*list of lists*) with values for step method array. 
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+        Array (*list of lists*) with values for step method array.
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be a deep copy.
         """
 
@@ -1153,10 +1153,10 @@ class allResults(object):
 
         self.circuit = None
         """
-        Circuit (*SLiCAPprotos.circuit*) used for this instruction.  
-        
-        Will be copied from **SLiCAPinstruction.instruction.circuit** at the 
-        start of the execution of the instruction. This instance will not be a 
+        Circuit (*SLiCAPprotos.circuit*) used for this instruction.
+
+        Will be copied from **SLiCAPinstruction.instruction.circuit** at the
+        start of the execution of the instruction. This instance will not be a
         deep copy.
         """
 
@@ -1204,66 +1204,41 @@ class allResults(object):
         """
         Label to be used in plots.
         """
-        
+
         self.parDefs = None
         """
-        Parameter definitions for the instruction.  
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+        Parameter definitions for the instruction.
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be e deep copy.
         """
         self.pairedVars   = None
         """
-        Extension of paired nodes and branches for base transformation of the circuit.  
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+        Extension of paired nodes and branches for base transformation of the circuit.
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be e deep copy.
         """
         self.pairedCircuits = None
         """
-        Identifiers of paired subcircuits for base transformation of the circuit.  
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+        Identifiers of paired subcircuits for base transformation of the circuit.
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be e deep copy.
         """
         self.removePairSubName = False
         """
         Setting for changing the parameter names of paired subcircuits.
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be e deep copy.
         """
-        
+
     def depVars(self):
         """
         Returns the list of detecors available AFTER execution of an instruction.
         """
         return [str(var) for var in self.Dv]
 
-def makeDir(dirName):
-    """
-    Creates the directory 'dirName' if it does not yet exist.
-
-    :param dirName: Name of the ditectory.
-    :type dirName: str
-    """
-
-    if not os.path.exists(dirName):
-        os.makedirs(dirName)
-    return
-
-def copyNotOverwrite(src, dest):
-    """
-    Copies the file 'src' to 'dest' if the latter one does not exist.
-
-    :param src: Name of the source file.
-    :type src: str
-
-    :param dest: Name of the desitination file.
-    :type dest: str
-    """
-    if not os.path.exists(dest):
-        cp(src, dest)
-    return
 
 initAll() # Initialize all models, devices, etc.

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,0 +1,46 @@
+import pytest
+import sympy as sp
+
+from SLiCAP import *  # TODO: change imports when import chain is reworked
+import SLiCAP.SLiCAPmath as sm
+
+SYMBOLIC_MATRIX = sp.sympify(
+    "Matrix([[0, 0, 0, 0, 0, 1.0, 0],\
+             [0, -2.0, 0, 0, 1.0*g_m1, 1.0*g_m1, 0],\
+             [0, 0, -2.0, 1.0*g_m2, -1.0*g_m2, 0, 0],\
+             [0, 1.0, 0, 0.5*c_i2*s + 0.5/r_o1, -0.5*c_i2*s + 0.5/r_o1, 0, 0],\
+             [0, 1.0, -1.0, -0.5*c_i2*s + 0.5/r_o1, 0.5*c_i1*s + 0.5*c_i2*s + 0.5/r_o2 + 0.5/r_o1 + 1.0/R, 0.5*c_i1*s, -0.5/r_o2],\
+             [1.0, 0, 0, 0, 0.5*c_i1*s, 0.5*c_i1*s, 0],\
+             [0, 0, 1.0, 0, -0.5/r_o2, 0, 0.5/r_o2 + 1.0/R_L]])"
+    )
+
+# Calculated offline with SymPy's det()
+DETERMINANT = sp.sympify(
+    "-1.0*(0.5*R*R_L*c_i1*c_i2*r_o1*s**2 + 0.5*R*R_L*c_i1*s\
+    + 1.0*R*R_L*c_i2*g_m1*r_o1*s + 2.0*R*R_L*c_i2*s + 1.0*R*c_i1*c_i2*r_o1*r_o2*s**2\
+    + 1.0*R*c_i1*r_o2*s + 2.0*R*c_i2*g_m1*r_o1*r_o2*s + 1.0*R*c_i2*r_o1*s\
+    + 4.0*R*c_i2*r_o2*s + 1.0*R*g_m1*g_m2*r_o1*r_o2 + 2.0*R*g_m2*r_o2 + 1.0*R\
+    + 1.0*R_L*c_i2*r_o1*s + 1.0*R_L + 2.0*c_i2*r_o1*r_o2*s + 2.0*r_o2)/(R*R_L*r_o1*r_o2)"
+    )
+
+
+def test_det_empty():
+    # Determinant of empty matrix should throw an exception
+    with pytest.raises(ValueError):
+        sm.det(sp.Matrix([]))
+
+
+def test_det_nonsq():
+    # Determinant of non-square matrix should throw an exception
+    with pytest.raises(TypeError):
+        sm.det(sp.Matrix([1, 2, 3]))
+
+
+@pytest.mark.parametrize("matrix, determinant", [
+        (sp.Matrix([[0, 0], [0, 0]]), sp.N(0)),
+        (sp.Matrix([[1, 2], [-1, -2]]), sp.N(0)),
+        (sp.Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), sp.N(1)),
+        (SYMBOLIC_MATRIX, DETERMINANT),
+    ])
+def test_det(matrix, determinant):
+    assert sp.simplify(sm.det(matrix) - determinant) == 0

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -4,23 +4,25 @@ import sympy as sp
 from SLiCAP import *  # TODO: change imports when import chain is reworked
 import SLiCAP.SLiCAPmath as sm
 
-SYMBOLIC_MATRIX = sp.sympify(
-    "Matrix([[0, 0, 0, 0, 0, 1.0, 0],\
-             [0, -2.0, 0, 0, 1.0*g_m1, 1.0*g_m1, 0],\
-             [0, 0, -2.0, 1.0*g_m2, -1.0*g_m2, 0, 0],\
-             [0, 1.0, 0, 0.5*c_i2*s + 0.5/r_o1, -0.5*c_i2*s + 0.5/r_o1, 0, 0],\
-             [0, 1.0, -1.0, -0.5*c_i2*s + 0.5/r_o1, 0.5*c_i1*s + 0.5*c_i2*s + 0.5/r_o2 + 0.5/r_o1 + 1.0/R, 0.5*c_i1*s, -0.5/r_o2],\
-             [1.0, 0, 0, 0, 0.5*c_i1*s, 0.5*c_i1*s, 0],\
-             [0, 0, 1.0, 0, -0.5/r_o2, 0, 0.5/r_o2 + 1.0/R_L]])"
+SYMBOLIC_MATRIX = sp.sympify("""Matrix([
+        [0, 0, 0, 0, 0, 1.0, 0],
+        [0, -2.0, 0, 0, 1.0*g_m1, 1.0*g_m1, 0],
+        [0, 0, -2.0, 1.0*g_m2, -1.0*g_m2, 0, 0],
+        [0, 1.0, 0, 0.5*c_i2*s + 0.5/r_o1, -0.5*c_i2*s+ 0.5/r_o1, 0, 0],
+        [0, 1.0, -1.0, -0.5*c_i2*s + 0.5/r_o1,
+         0.5*c_i1*s+ 0.5*c_i2*s + 0.5/r_o2 + 0.5/r_o1 + 1.0/R, 0.5*c_i1*s, -0.5/r_o2],
+        [1.0, 0, 0, 0, 0.5*c_i1*s, 0.5*c_i1*s, 0],
+        [0, 0, 1.0, 0, -0.5/r_o2, 0, 0.5/r_o2 + 1.0/R_L]])"""
     )
 
 # Calculated offline with SymPy's det()
-DETERMINANT = sp.sympify(
-    "-1.0*(0.5*R*R_L*c_i1*c_i2*r_o1*s**2 + 0.5*R*R_L*c_i1*s\
-    + 1.0*R*R_L*c_i2*g_m1*r_o1*s + 2.0*R*R_L*c_i2*s + 1.0*R*c_i1*c_i2*r_o1*r_o2*s**2\
-    + 1.0*R*c_i1*r_o2*s + 2.0*R*c_i2*g_m1*r_o1*r_o2*s + 1.0*R*c_i2*r_o1*s\
-    + 4.0*R*c_i2*r_o2*s + 1.0*R*g_m1*g_m2*r_o1*r_o2 + 2.0*R*g_m2*r_o2 + 1.0*R\
-    + 1.0*R_L*c_i2*r_o1*s + 1.0*R_L + 2.0*c_i2*r_o1*r_o2*s + 2.0*r_o2)/(R*R_L*r_o1*r_o2)"
+DETERMINANT = sp.sympify("""
+    -1.0*(0.5*R*R_L*c_i1*c_i2*r_o1*s**2 + 0.5*R*R_L*c_i1*s + 1.0*R*R_L*c_i2*g_m1*r_o1*s
+    + 2.0*R*R_L*c_i2*s + 1.0*R*c_i1*c_i2*r_o1*r_o2*s**2
+    + 1.0*R*c_i1*r_o2*s + 2.0*R*c_i2*g_m1*r_o1*r_o2*s + 1.0*R*c_i2*r_o1*s
+    + 4.0*R*c_i2*r_o2*s + 1.0*R*g_m1*g_m2*r_o1*r_o2 + 2.0*R*g_m2*r_o2 + 1.0*R
+    + 1.0*R_L*c_i2*r_o1*s + 1.0*R_L + 2.0*c_i2*r_o1*r_o2*s + 2.0*r_o2)/(R*R_L*r_o1*r_o2)
+    """
     )
 
 
@@ -37,6 +39,7 @@ def test_det_nonsq():
 
 
 @pytest.mark.parametrize("matrix, determinant", [
+        (sp.Matrix([-1.5e-5]), sp.N(-1.5e-5)),
         (sp.Matrix([[0, 0], [0, 0]]), sp.N(0)),
         (sp.Matrix([[1, 2], [-1, -2]]), sp.N(0)),
         (sp.Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), sp.N(1)),

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -9,7 +9,7 @@ import os
 
 def test_pytest():
     assert 4==4
-    
+
 def test_CSresnoise():
     ini.installPath = os.getcwd() + '/'
     ini.projectPath = ini.installPath + 'files/examples/CSstage/'
@@ -31,14 +31,14 @@ def test_CSresnoise():
     IC      = i1.getParValue('IC_X1')
     IC_CRIT = i1.getParValue('IC_CRIT_X1')
     I_D     = I_D*IC_CRIT/IC
-    
+
     i1.circuit.defPar('ID', I_D)
     R_N   = i1.getParValue('R_N_X1')
     R_s   = i1.getParValue('R_s')
     f_T   = i1.getParValue('f_T_X1')
     g_m   = i1.getParValue('g_m_X1')
     Width = i1.getParValue('W')
-    
+
     i1.setSource('V1')
     i1.setDetector('V_out')
     i1.setGainType('vi')
@@ -46,11 +46,11 @@ def test_CSresnoise():
     i1.setSimType('numeric')
     noise_result = i1.execute()
     # plotSweep('Inoise', 'Source-referred noise spectrum', noise_result, 1e8, 1e11, 100, funcType = 'inoise', show=False)
-    
+
     # Calculate the noise figure at critical inversion and the given width
     tot_inoise      = rmsNoise(noise_result, 'inoise', 1e9, 5e9)
     tot_inoise_src  = rmsNoise(noise_result, 'inoise', 1e9, 5e9, source = noise_result.source)
-    
+
     NF              = 20*sp.log(tot_inoise/tot_inoise_src)/sp.log(10)
     print(NF)
     shifted = int(NF*1000)
@@ -79,18 +79,6 @@ def test_lex2():
     print('\nnumber of errors =', lexer.errCount, '\n')
     #Add assert statement
 
-def test_matrix():
-        s = ini.Laplace
-        MNA = matrix([[5.0e-12*s + 0.01, 0, 0, -5.0e-12*s - 0.01, 0, 0, 0, 0, 1],
-                      [0, 1.98e-11*s + 0.0001, -1.2e-11*s, -1.8e-12*s - 1.0e-5, 0, 0, 0, 0, 0],
-                      [0, -1.2e-11*s, 2.8e-11*s + 0.001, 0, -1.0e-11*s - 0.001, 0, 0, -1, 0],
-                      [-5.0e-12*s - 0.01, -1.8e-12*s - 1.0e-5, 0, 1.0068e-9*s + 0.01101, 0, 0, 1, 0, 0],
-                      [0, 0, -1.0e-11*s - 0.001, 0, 1.0e-11*s + 0.001, 1, 0, 1, 0],
-                      [0, 0, 0, 0, 1, 0, 0, 0, 0],
-                      [0, 0, 0, 1, 0, 0, -1.0e-6*s, -3.1623e-11*s, 0],
-                      [0, 0, -1, 0, 1, 0, -3.1623e-11*s, -1.0e-9*s, 0],
-                      [2.048e-20*s**3 + 2.688e-11*s**2 + 0.0016*s + 1, 0, 0, 0, 0, 0, 0, 0, 0]])
-        print(MNA.determinant())
 
 def test_yacc():
     ini.installPath = os.getcwd() + '/'
@@ -186,4 +174,3 @@ def test_python_maxima():
     proto_transfer = sp.sympify('A/(1+s*tau)')
     circuit_component_values = equateCoeffs(proto_transfer, circuit_transfer, noSolve=['A','tau'], numeric=False)
     print(circuit_component_values)
-


### PR DESCRIPTION
Auxiliary functions `makeDir()` and `copyNotOverwrite()` were defined in SLiCAPprotos.py, while they are only used in SLiCAP.py, so I moved them there.

Another option, maybe for later if needed, is to create a utils.py file with small helper functions if used in several places.