### PR TITLE
Remove cp alias

### DIFF
--- a/SLiCAP/SLiCAP.py
+++ b/SLiCAP/SLiCAP.py
@@ -7,7 +7,39 @@ When working with Jupyter notebooks the main imort module is SLiCAPnotebook.py.
 It will import SLiCAP.py and some extra modules for displaying LaTeX, SVG and
 RST in the Jupyter notebooks.
 """
+
+import os
+import shutil
+
 from SLiCAP.SLiCAPdesignData import *
+
+
+def makeDir(dirName):
+    """
+    Create the directory 'dirName' if it does not yet exist.
+
+    :param dirName: Name of the ditectory.
+    :type dirName: str
+    """
+    # FIXME: existence check might not be necessary when using makedirs()
+    # See: https://docs.python.org/3/library/os.html#os.makedirs
+    if not os.path.exists(dirName):
+        os.makedirs(dirName)
+
+
+def copyNotOverwrite(src, dest):
+    """
+    Copy the file 'src' to 'dest' if the latter does not exist.
+
+    :param src: Name of the source file.
+    :type src: str
+
+    :param dest: Name of the desitination file.
+    :type dest: str
+    """
+    if not os.path.exists(dest):
+        shutil.copy2(src, dest)
+
 
 try:
     __IPYTHON__
@@ -56,10 +88,10 @@ def initProject(name, port=ini.PORT):
     :param name: Name of the project will be passed to an instance of the
                  SLiCAPproject object.
     :type name: str
-    
+
     :param port: Port number for communication with maxima CAS (> 8000).
     :type port: int
-    
+
     :return:     SLiCAPproject
     :rtype:      SLiCAP.SLiCAPproject
 
@@ -143,18 +175,18 @@ def initProject(name, port=ini.PORT):
         # Create the libraries
     if len(SLiCAPCIRCUITS) == 0:
         makeLibraries()
-    return prj    
+    return prj
 
 def makeNetlist(fileName, cirTitle):
     """
     Creates a netlist from a schematic file generated with LTspice or gschem.
-    
+
     - LTspice: '.asc' file
     - gschem: '.sch' file
-    
+
     :param fileName: Name of the file, relative to **ini.circuitPath**
     :type fileName: str
-    
+
     :param cirTitle: Title of the schematic.
     :type cirTitle: str
     """
@@ -168,7 +200,7 @@ def makeNetlist(fileName, cirTitle):
         if fileType == 'asc':
             file = os.path.abspath(baseFileName + '.asc')
             print(file)
-            if platform.system() == 'Windows':    
+            if platform.system() == 'Windows':
                 file = file.replace('\\','\\\\')
                 subprocess.run([ini.ltspice, '-netlist', file])
             else:
@@ -186,13 +218,13 @@ def makeNetlist(fileName, cirTitle):
             outputfile = os.path.abspath(baseFileName + '.net')
             inputfile = os.path.abspath(baseFileName + '.sch')
             print('input: ',inputfile, ' output: ', outputfile)
-            if platform.system() != 'Windows':    
+            if platform.system() != 'Windows':
                 try:
                     subprocess.run(['lepton-netlist', '-g', 'spice-noqsi', '-o', outputfile, inputfile])
                 except:
                     print("Could not generate netlist using Lepton-eda")
             try:
-                if platform.system() == 'Windows':    
+                if platform.system() == 'Windows':
                     outputfile = outputfile.replace('\\','\\\\')
                     inputfile = inputfile.replace('\\','\\\\')
                 subprocess.run(['gnetlist', '-q', '-g', 'spice-noqsi', '-o', outputfile, inputfile])

--- a/SLiCAP/SLiCAPhtml/SLiCAPhtml.py
+++ b/SLiCAP/SLiCAPhtml/SLiCAPhtml.py
@@ -5,6 +5,7 @@ SLiCAP module with HTML functions.
 
 This module is imported by SLiCAPyacc.py
 """
+import shutil
 
 from SLiCAP.SLiCAPplots import *
 
@@ -464,7 +465,7 @@ def img2html(fileName, width, label = '', caption = ''):
         ini.htmlLabels[label] = newlabel
         label = '<a id="' + label + '"></a>'
     try:
-        cp(ini.imgPath + fileName, ini.htmlPath + 'img/' + fileName)
+        shutil.copy2(ini.imgPath + fileName, ini.htmlPath + 'img/' + fileName)
     except:
         print("Error: could not copy: '{0}'.".format(fileName))
     html = '<figure>{0}<img src="img/{1}" alt="{2}" style="width:{3}px">\n'.format(label, fileName, caption, width)
@@ -637,7 +638,7 @@ def pz2html(instObj, label = '', labelText = ''):
         return html
     elif instObj.dataType != 'poles' and instObj.dataType != 'zeros' and instObj.dataType != 'pz':
         print("Error: 'pz2html()' expected dataType: 'poles', 'zeros', or 'pz', got: '{0}'.".format(instObj.dataType))
-        return html 
+        return html
     elif instObj.step == True :
         print("Error: parameter stepping not implemented for 'pz2html()'.")
         return html
@@ -909,7 +910,7 @@ def coeffsTransfer2html(transferCoeffs, label = '', labelText = ''):
 def stepArray2html(stepVars, stepArray):
     """
     Displays the step array on the active HTML page.
-    
+
     :return: html: HTML string that will be placed on the page.
     :rtype: str
     """
@@ -948,7 +949,7 @@ def fig2html(figureObject, width, label = '', caption = ''):
     html += '</figure>\n'
     insertHTML(ini.htmlPath + ini.htmlPage, html)
     try:
-        cp(ini.imgPath + figureObject.fileName, ini.htmlPath + 'img/' + figureObject.fileName)
+        shutil.copy2(ini.imgPath + figureObject.fileName, ini.htmlPath + 'img/' + figureObject.fileName)
     except:
         print("Error: could not copy: '{0}'.".format(ini.imgPath + figureObject.fileName))
     return ini.htmlPath + 'img/' + figureObject.fileName
@@ -956,7 +957,7 @@ def fig2html(figureObject, width, label = '', caption = ''):
 def file2html(fileName):
     """
     Writes the contents of a file to the active html page.
-    
+
     :param fileName: Name of the file (relative to ini.textPath)
     :type fileName: str
     :return: html code
@@ -990,15 +991,15 @@ def href(label, fileName = ''):
 def links2html():
     """
     Returns the HTML code for placing links to all labeled HTML objects.
-    
+
     Links will be grouped as follows:
-        
+
     #. Links to headings
     #. Links to circuit data and imported tables
     #. Links to figures
     #. Links to equations
     #. Links to analysis results (from noise2html, pz2html, etc.)
-    
+
     :return: html: HTML string that will be placed on the page.
     :rtype: str
     """
@@ -1038,10 +1039,10 @@ def links2html():
 def htmlLink(address, text):
     """
     Returns the html code for placing a link on an html page with *text2html()*.
-    
+
     :param address: link address
     :type address: str
-    
+
     :return: html code
     :rtype: str
     """
@@ -1056,7 +1057,7 @@ def htmlParValue(instr, parName):
 
     :param instr: Instruction that holds the parameter definition
     :type instr: SLiCAPinstruction.instruction
-    
+
     :param parName: Name of the parameter
     :type parName: string
 
@@ -1073,7 +1074,7 @@ def htmlElValue(instr, elName):
 
     :param instr: Instruction that holds the parameter definition
     :type instr: SLiCAPinstruction.instruction
-    
+
     :param elName: Element identifier
     :type elName: string
 

--- a/SLiCAP/SLiCAPini/SLiCAPini.py
+++ b/SLiCAP/SLiCAPini/SLiCAPini.py
@@ -31,12 +31,11 @@ from scipy.signal import residue
 from scipy.optimize import newton, fsolve
 from scipy.integrate import quad
 from threading import Thread, Lock
-from shutil import copy2 as cp
 from time import time, sleep
 from datetime import datetime
 plt.ioff() # Turn off the interactive mode for plotting
 # Increase width for display of numpy arrays:
-np.set_printoptions(edgeitems=30, linewidth=1000, 
+np.set_printoptions(edgeitems=30, linewidth=1000,
     formatter=dict(float=lambda x: "%11.4e" % x))
 
 def _selftest_maxima():
@@ -58,13 +57,13 @@ def _selftest_maxima():
         try:
             result = subprocess.run(['maxima', '--very-quiet', '-batch-string', maxInput], capture_output=True, timeout=3, text=True).stdout.split('\n')
 
-        
+
         except BaseException:
             exc_type, value, exc_traceback = sys.exc_info()
             print('\n', value)
             print("Not able to run the maxima command, verify maxima is installed by typing 'maxima' in the command line.")
             print("In case maxima is not installed, use your package manager to install it (f.e. 'sudo apt install maxima').")
-    
+
     result = [i for i in result if i] # Added due to variability of trailing '\n'
     result = result[-1]
     if int(result) == 2:
@@ -72,7 +71,7 @@ def _selftest_maxima():
     else:
         print("Something went wrong when testing Maxima, please re-run the installer and try to start maxima first by itself.")
 
-    
+
 def _check_version():
     """
     Checks the version with the latest version from Git
@@ -86,8 +85,8 @@ def _check_version():
         print("A new version of SLiCAP is available, please get it from 'https://github.com/Lenty/SLiCAP_python'.")
     else:
         print("SLiCAP Version matches with the latest release of SLiCAP on github.")
-        
-    
+
+
 def _get_latest_version():
     """
     Gets the SLiCAP version from Github (only possible when repository is public
@@ -172,7 +171,7 @@ class settings(object):
        - MaximaTimeOut     : Maximum calculation time for Maxima
        - assumePosMaxVars  : Assume postive parameters in Maxima expressions
        - lambdifyTool      : "numpy" or "mpmath"; latter one in case of overflow
-         
+
     #. Display settings
 
        - disp              : Number of digits for displaying floats on html pages
@@ -208,46 +207,46 @@ class settings(object):
     #. Maxima command setting (only required for MSWindows)
 
        - maxima: command to start maxima under MSWindows
-       
+
     #. Maxima execution method:
-        
-       - socket: 
-         
+
+       - socket:
+
          - True : maxima runs in a socket (passes maxima messages)
          - False : maxima runs as a subprocess (ignores maxima messages)
-         
+
        - HOST = 127.0.0.1 : Standard loopback interface address (localhost)
-       
+
        - PORT = 53118     : Port to listen on (non-privileged ports are > 1023)
-       
+
        - maximaHandler    : Maxima client process handler
-                 
+
     """
     def __init__(self):
         """
         Initializes the start-up values of the global parameters.
         """
-        
+
         self.installPath        = None
         """
         Installation path of SLiCAP (*str*), defaults to None.
         """
-        
+
         self.userPath        = None
         """
         User path of SLiCAP (*str*), defaults to None.
         """
-        
+
         self.defaultLib         = None
         """
         Default library path of SLiCAP (*str*), defaults to None.
         """
-        
+
         self.docPath            = None
         """
         Path with HTML documentation (*str*), defaults to None.
         """
-        
+
         self.projectPath        = None
         """
         Project path (*str*), will be set by **SLiCAP.initProject()**;  defaults to None.
@@ -282,7 +281,7 @@ class settings(object):
         """
         Path (*str*) for saving latex files, will be set by **SLiCAP.initProject()**;  defaults to None.
         """
-        
+
         self.sphinxPath         = None
         """
         Path (*str*) for saving sphinx files, will be set by **SLiCAP.initProject()**;  defaults to None.
@@ -341,7 +340,7 @@ class settings(object):
          - False: Step variables are substituted directly into the matrix.
            This method faster for large circuits, or for stepped instructions
            with multiple step variables.
-           
+
          """
 
         self.maxRecSubst        = 12
@@ -371,7 +370,7 @@ class settings(object):
         Symbol (*sympy.core.symbol.Symbol*) used for the Laplace variable.
         Defaults to sp.Symbol('s').
         """
-        
+
         self.frequency          = sp.Symbol('f')
         """
         Symbol (*sympy.core.symbol.Symbol*) used for frequency.
@@ -460,18 +459,18 @@ class settings(object):
         Maximum time in seconds (*int*) for subprocess to run Maxima. Defaults
         to 60.
         """
-        
+
         self.lambdifyTool       = "numpy"
         """
         Tool to be used for sympy.lamddify, can be "numpy" for fast calculation
         in case of overflow warning choose "mpmath"
         """
-        
+
         self.MaximaMatrixDim    = 25
         """
         Maximum size of sa square matrix to be passed to maxima.
         """
-        
+
         self.assumePosMaxVars   = True
         """
         Assume positive parameters in Maxima expressions. In many cases this
@@ -497,27 +496,27 @@ class settings(object):
 
         This variable is set during installation.
         """
-        
+
         self.socket             = True
         """
         Setting for maxima operation method.
         """
-        
-        self.HOST               = "127.0.0.1" 
+
+        self.HOST               = "127.0.0.1"
         """
         Standard loopback interface address (localhost)
         """
-        
+
         self.PORT               = 53118
         """
         Port to listen on (non-privileged ports are > 1023)
         """
-        
+
         self.maximaHandler      = None
         """
         Maxima client process handler will be activated at start-up
         """
-        
+
         self.netlist            = None
         """
         gschem or lepton-schematic command for generating a netlist.

--- a/SLiCAP/SLiCAPprotos/SLiCAPprotos.py
+++ b/SLiCAP/SLiCAPprotos/SLiCAPprotos.py
@@ -142,12 +142,12 @@ class circuit(object):
             - Gxxx, model = 'G', output port: 'Io_Gxxx'
             - Hxxx, input port: 'Ii_Hxxx', output port: 'Io_xxx'
         """
-        
+
         self.controlled = []
         """
         (*list*) with reference designators (*str*) of controlled sources.
         """
-        
+
         self.varIndex   = {}
         """
         (*dict*) with key-value pairs:
@@ -157,7 +157,7 @@ class circuit(object):
           before elemination of the row anmd column associated with the
           reference node '0'.
         """
-        
+
     def delPar(self, parName):
         """
         Deletes a parameter definition and updates the list
@@ -318,7 +318,7 @@ class circuit(object):
             print("Error: parameter '{0}' has not been defined.".format(str(parNames)))
             parValue = None
         return parValue
-    
+
     def updateParams(self):
         """
         Updates self.params (list with undefined parameters) after modification
@@ -347,44 +347,44 @@ class circuit(object):
                 undefined.append(par)
         self.params = undefined
         return
-        
+
     def getElementValue(self, elementID, param, numeric):
         """
         Returns the value or expression of one or more circuit elements.
-        
-        If instruction.numeric == True it will perform a full recursive 
+
+        If instruction.numeric == True it will perform a full recursive
         substitution of all circuit parameter definitions.
-        
-        This method is called by instruction.circuit.getElementValue() with 
+
+        This method is called by instruction.circuit.getElementValue() with
         keyword arg numeric = True if instruction.simType is set to 'numeric'.
-        
+
         :param elementID: name(s) of the element(s)
-        :type elementID: str, list 
-        
+        :type elementID: str, list
+
         :param param: name of the parameter (equal for all elements):
-            
+
                       - 'value': Laplace value
                       - 'dc': DC value (independent sources only)
                       - 'noise': Noise spectral density (independent sources only)
                       - 'dcvar': DC variance (independent sources only)
-                      
+
         :type param: str
-        
+
         :return: if type(parNames) == list:
-            
-                 return value = dict with key-value pairs: key (*sympy.core.symbol.Symbol*): 
-                 name of the parameter, value (*int, float, sympy expression*): 
+
+                 return value = dict with key-value pairs: key (*sympy.core.symbol.Symbol*):
+                 name of the parameter, value (*int, float, sympy expression*):
                  value of the parameter
-                 
+
                  else:
                  value or expression
-                 
+
         :rtype: dict, float, int, sympy.Expr
-        
+
         :Example:
-         
+
         >>> # Create an instance if a SLiCAP instruction
-        >>> my_instr = instruction()  
+        >>> my_instr = instruction()
         >>> # Create my_instr.circuit from the netlist 'myFirstRCnetwork.cir'
         >>> my_instr.setCircuit('myFirstRCnetwork.cir')
         >>> # Obtain the numeric value of 'R1' and 'C1':
@@ -880,7 +880,7 @@ def initAll():
 
 class allResults(object):
     """
-    Return  structure for results, has attributes with 
+    Return  structure for results, has attributes with
     instruction data and execution results.
     """
     def __init__(self):
@@ -931,7 +931,7 @@ class allResults(object):
         """
         DC solution of the network.
         """
-        
+
         self.timeSolve   = []
         """
         Time-domain solution of the network.
@@ -975,7 +975,7 @@ class allResults(object):
         """
         MNA matrix.
         """
-        
+
         self.A           = None
         """
         Base conversion matrix.
@@ -1113,17 +1113,17 @@ class allResults(object):
 
         self.stepList = []
         """
-        List with values for step method 'list'.  
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+        List with values for step method 'list'.
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be a deep copy.
         """
 
         self.stepArray = []
         """
-        Array (*list of lists*) with values for step method array. 
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+        Array (*list of lists*) with values for step method array.
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be a deep copy.
         """
 
@@ -1153,10 +1153,10 @@ class allResults(object):
 
         self.circuit = None
         """
-        Circuit (*SLiCAPprotos.circuit*) used for this instruction.  
-        
-        Will be copied from **SLiCAPinstruction.instruction.circuit** at the 
-        start of the execution of the instruction. This instance will not be a 
+        Circuit (*SLiCAPprotos.circuit*) used for this instruction.
+
+        Will be copied from **SLiCAPinstruction.instruction.circuit** at the
+        start of the execution of the instruction. This instance will not be a
         deep copy.
         """
 
@@ -1204,66 +1204,41 @@ class allResults(object):
         """
         Label to be used in plots.
         """
-        
+
         self.parDefs = None
         """
-        Parameter definitions for the instruction.  
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+        Parameter definitions for the instruction.
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be e deep copy.
         """
         self.pairedVars   = None
         """
-        Extension of paired nodes and branches for base transformation of the circuit.  
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+        Extension of paired nodes and branches for base transformation of the circuit.
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be e deep copy.
         """
         self.pairedCircuits = None
         """
-        Identifiers of paired subcircuits for base transformation of the circuit.  
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+        Identifiers of paired subcircuits for base transformation of the circuit.
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be e deep copy.
         """
         self.removePairSubName = False
         """
         Setting for changing the parameter names of paired subcircuits.
-        
-        Will be copied from **SLiCAPinstruction.instruction** at the start of 
+
+        Will be copied from **SLiCAPinstruction.instruction** at the start of
         the execution of the instruction. This instance will be e deep copy.
         """
-        
+
     def depVars(self):
         """
         Returns the list of detecors available AFTER execution of an instruction.
         """
         return [str(var) for var in self.Dv]
 
-def makeDir(dirName):
-    """
-    Creates the directory 'dirName' if it does not yet exist.
 
-    :param dirName: Name of the ditectory.
-    :type dirName: str
-    """
-
-    if not os.path.exists(dirName):
-        os.makedirs(dirName)
-    return
-
-def copyNotOverwrite(src, dest):
-    """
-    Copies the file 'src' to 'dest' if the latter one does not exist.
-
-    :param src: Name of the source file.
-    :type src: str
-
-    :param dest: Name of the desitination file.
-    :type dest: str
-    """
-    if not os.path.exists(dest):
-        cp(src, dest)
-    return
-
-initAll() # Initialize all models, devices, etc.
+initAll()  # Initialize all models, devices, etc.


### PR DESCRIPTION
The `cp` alias for `shutil.copy2` is inneccessary and misleading, defined in `SLiCAPini.py` and only used in two functions of `SLiCAPhtml.py`. It has been removed in favor of explicitly `import`ing `shutil` in the file where it is used.